### PR TITLE
Allocate credit note with both #save and #save!

### DIFF
--- a/lib/xeroizer/models/credit_note.rb
+++ b/lib/xeroizer/models/credit_note.rb
@@ -134,7 +134,7 @@ module Xeroizer
           parent.pdf(id, filename)
         end
 
-        def save
+        def save!
           # Calling parse_save_response() on the credit note will wipe out
           # the allocations, so we have to manually preserve them.
           allocations_backup = self.allocations


### PR DESCRIPTION
Since `#save` invokes `#save!` internally, not the other way around,
CreditNote was not allocated with `#save!`.