### PR TITLE
Conditionally validate line item description

### DIFF
--- a/lib/xeroizer/models/line_item.rb
+++ b/lib/xeroizer/models/line_item.rb
@@ -24,7 +24,7 @@ module Xeroizer
 
       has_many  :tracking, :model_name => 'TrackingCategoryChild'
 
-      validates_presence_of :description
+      validates_presence_of :description, :unless => Proc.new { |line_item| line_item.item_code.present? }
 
       def initialize(parent)
         super(parent)


### PR DESCRIPTION
When item_code is given, Xero API does not require the description to be set, 
as it will pull the description from given item. Without this change it's not possible
to create an invoice without setting the description, as it will raise the 
"Line items must all be valid" error.