### PR TITLE
Use Retry-After header for smart rate limit backoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,15 +587,24 @@ By default, the library will raise a `Xeroizer::OAuth::RateLimitExceeded`
 exception when one of these limits is exceeded.
 
 If required, the library can handle these exceptions internally by sleeping
-for a configurable number of seconds and then repeating the last request.
-You can set this option when initializing an application:
+and then repeating the last request. You can set this option when initializing
+an application:
 
 ```ruby
-# Sleep for 2 seconds every time the rate limit is exceeded.
+# Sleep for the duration specified in Xero's Retry-After header.
+client = Xeroizer::OAuth2Application.new(YOUR_OAUTH2_CLIENT_ID,
+                                         YOUR_OAUTH2_CLIENT_SECRET,
+                                         :rate_limit_sleep => true)
+
+# Sleep for a fixed 2 seconds every time the rate limit is exceeded.
 client = Xeroizer::OAuth2Application.new(YOUR_OAUTH2_CLIENT_ID,
                                          YOUR_OAUTH2_CLIENT_SECRET,
                                          :rate_limit_sleep => 2)
 ```
+
+When set to `true`, the library uses the `Retry-After` value from the API
+response to determine how long to wait. When set to a number, it always
+sleeps for that many seconds instead.
 
 Xero API Nonce Used
 -------------------

--- a/lib/xeroizer/http.rb
+++ b/lib/xeroizer/http.rb
@@ -115,11 +115,16 @@ module Xeroizer
         logger.info("Nonce used: " + exception.to_s) if self.logger
         sleep_for(1)
         retry
-      rescue Xeroizer::OAuth::RateLimitExceeded
+      rescue Xeroizer::OAuth::RateLimitExceeded => exception
         if self.rate_limit_sleep
           raise if attempts > rate_limit_max_attempts
-          logger.info("Rate limit exceeded, retrying") if self.logger
-          sleep_for(self.rate_limit_sleep)
+          sleep_duration = if self.rate_limit_sleep == true
+                            (exception.retry_after && exception.retry_after > 0) ? exception.retry_after : 1
+                          else
+                            self.rate_limit_sleep
+                          end
+          logger.info("Rate limit exceeded, retrying in #{sleep_duration}s") if self.logger
+          sleep_for(sleep_duration)
           retry
         else
           raise

--- a/test/unit/http_test.rb
+++ b/test/unit/http_test.rb
@@ -186,6 +186,79 @@ class HttpTest < UnitTestCase
       end
     end
 
+    context "rate_limit_sleep with retry-after" do
+      setup do
+        @retry_after_seconds = 42
+        stub_request(:get, @uri).to_return(
+          status: 429,
+          body: "",
+          headers: {
+            "x-daylimit-remaining" => "328",
+            "retry-after" => @retry_after_seconds.to_s,
+          }
+        ).then.to_return(status: 200, body: "<Response/>")
+      end
+
+      context "when rate_limit_sleep is true" do
+        setup do
+          @application = Xeroizer::OAuth2Application.new(
+            CLIENT_ID, CLIENT_SECRET,
+            tenant_id: TENANT_ID, access_token: ACCESS_TOKEN,
+            rate_limit_sleep: true
+          )
+        end
+
+        should "sleep for the retry-after duration from the response" do
+          @application.expects(:sleep_for).with(@retry_after_seconds)
+          @application.http_get(@application.client, @uri)
+        end
+      end
+
+      context "when rate_limit_sleep is a number" do
+        setup do
+          @application = Xeroizer::OAuth2Application.new(
+            CLIENT_ID, CLIENT_SECRET,
+            tenant_id: TENANT_ID, access_token: ACCESS_TOKEN,
+            rate_limit_sleep: 5
+          )
+        end
+
+        should "sleep for the configured number of seconds" do
+          @application.expects(:sleep_for).with(5)
+          @application.http_get(@application.client, @uri)
+        end
+      end
+
+      context "when rate_limit_sleep is true but retry-after is missing" do
+        setup do
+          WebMock.reset!
+          stub_request(:get, @uri).to_return(
+            status: 429,
+            body: "",
+            headers: {}
+          ).then.to_return(status: 200, body: "<Response/>")
+          @application = Xeroizer::OAuth2Application.new(
+            CLIENT_ID, CLIENT_SECRET,
+            tenant_id: TENANT_ID, access_token: ACCESS_TOKEN,
+            rate_limit_sleep: true
+          )
+        end
+
+        should "fall back to sleeping for 1 second" do
+          @application.expects(:sleep_for).with(1)
+          @application.http_get(@application.client, @uri)
+        end
+      end
+
+      context "when rate_limit_sleep is false" do
+        should "raise without retrying" do
+          assert_raises(Xeroizer::OAuth::RateLimitExceeded) {
+            @application.http_get(@application.client, @uri)
+          }
+        end
+      end
+    end
+
     context "503" do
       setup do
         @status_code = 503


### PR DESCRIPTION
## Summary
- When `rate_limit_sleep` is set to `true`, Xeroizer now sleeps for the duration specified in Xero's `Retry-After` response header instead of requiring a fixed number of seconds
- Falls back to 1 second if the header is missing (e.g. from the OAuth 401 rate limit path)
- Existing behavior unchanged: numeric values use fixed sleep, `false` re-raises immediately

## Test plan
- [x] New test: `rate_limit_sleep: true` sleeps for `retry-after` header value
- [x] New test: `rate_limit_sleep: <number>` still sleeps for fixed duration
- [x] New test: `rate_limit_sleep: true` with missing header falls back to 1s
- [x] New test: `rate_limit_sleep: false` raises without retrying
- [x] All 24 HTTP tests pass, no regressions